### PR TITLE
RELATED: RAIL-4633 Rename metadata objects

### DIFF
--- a/gooddemo/workspaces/demo/ldm.json
+++ b/gooddemo/workspaces/demo/ldm.json
@@ -14,13 +14,13 @@
             "sourceColumn": "campaign_channel_id"
           },
           {
-            "description": "Category",
+            "description": "Campaign channel category",
             "id": "campaign_channels.category",
             "labels": [],
             "tags": [
               "Campaign channels"
             ],
-            "title": "Category",
+            "title": "Campaign channel category",
             "sourceColumn": "category"
           },
           {
@@ -336,13 +336,13 @@
             "sourceColumn": "product_name"
           },
           {
-            "description": "Category",
+            "description": "Product category",
             "id": "products.category",
             "labels": [],
             "tags": [
               "Products"
             ],
-            "title": "Category",
+            "title": "Product category",
             "sourceColumn": "category"
           }
         ],

--- a/gooddemo/workspaces/demo/workspaceAnalytics.json
+++ b/gooddemo/workspaces/demo/workspaceAnalytics.json
@@ -5368,8 +5368,8 @@
           "visualizationUrl": "local:donut"
         },
         "description": "",
-        "id": "product_categories_pie_chart",
-        "title": "Product Categories Pie Chart"
+        "id": "product_categories_donut_chart",
+        "title": "Product Categories Donut Chart"
       },
       {
         "content": {


### PR DESCRIPTION
* Duplicate names created ugly metadata exports for GD.UI ("Category" and "Category_1"), so I made those more specific.
* A pie chart is actually a donut chart, so I renamed it.